### PR TITLE
feat(rbac): Add caching for SelfSubjectAccessReview to reduce API calls

### DIFF
--- a/internal/rbac/rbac.go
+++ b/internal/rbac/rbac.go
@@ -2,7 +2,10 @@ package rbac
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
+	"sync"
+	"time"
 
 	xcontext "github.com/krateoplatformops/plumbing/context"
 	"github.com/krateoplatformops/plumbing/kubeconfig"
@@ -18,8 +21,37 @@ type UserCanOptions struct {
 	Namespace     string
 }
 
+type cacheEntry struct {
+	allowed bool
+	expiry  time.Time
+}
+
+var (
+	rbacCache = make(map[string]cacheEntry)
+	mutex     = &sync.Mutex{}
+)
+
+const (
+	cacheTTL = 10 * time.Second
+)
+
 func UserCan(ctx context.Context, opts UserCanOptions) (ok bool) {
 	log := xcontext.Logger(ctx)
+
+	key, err := cacheKey(ctx, opts)
+	if err != nil {
+		log.Error("unable to generate cache key", slog.Any("err", err))
+		return false
+	}
+
+	mutex.Lock()
+	entry, found := rbacCache[key]
+	mutex.Unlock()
+
+	if found && time.Now().Before(entry.expiry) {
+		log.Debug("SelfSubjectAccessReviews result from cache", slog.Any("key", key))
+		return entry.allowed
+	}
 
 	ep, err := xcontext.UserConfig(ctx)
 	if err != nil {
@@ -60,5 +92,23 @@ func UserCan(ctx context.Context, opts UserCanOptions) (ok bool) {
 
 	log.Debug("SelfSubjectAccessReviews result", slog.Any("response", resp))
 
+	mutex.Lock()
+	rbacCache[key] = cacheEntry{
+		allowed: resp.Status.Allowed,
+		expiry:  time.Now().Add(cacheTTL),
+	}
+	mutex.Unlock()
+
 	return resp.Status.Allowed
+}
+
+func cacheKey(ctx context.Context, opts UserCanOptions) (string, error) {
+	usr, err := xcontext.User(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("%s:%s:%s:%s:%s",
+		usr, opts.Verb, opts.GroupResource.Group,
+		opts.GroupResource.Resource, opts.Namespace), nil
 }


### PR DESCRIPTION
This PR addresses the issue of excessive `SelfSubjectAccessReview` API calls, which can lead to Kubernetes API rate-limiting.

### Problem

The `resolveOne` function in `internal/resolvers/widgets/resourcesrefs/resolve.go` calls `rbac.UserCan` within a loop. The `rbac.UserCan` function in `internal/rbac/rbac.go` performs a `SelfSubjectAccessReview` API call every time it's invoked. This results in a high volume of API requests, especially when dealing with multiple resource references, increasing the risk of hitting API rate limits.

### Solution

This PR introduces an in-memory caching mechanism for `SelfSubjectAccessReview` results in `internal/rbac/rbac.go`. The cache stores the results of `SelfSubjectAccessReview` calls for a short duration (10 seconds) and is keyed by user, verb, group, resource, and namespace. This ensures that repeated checks for the same permissions within a short time frame will be served from the cache, significantly reducing the number of API calls to the Kubernetes API server.

### Files Modified

-   `internal/rbac/rbac.go`: Implemented the caching logic within the `UserCan` function.
-   `internal/resolvers/widgets/resourcesrefs/resolve.go`: This file benefits from the reduced API calls, but no changes were required here.